### PR TITLE
feat: add support of clearMeasures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ if (perf && perf.mark && perf.measure && perf.clearMeasures) {
     return entry
   }
   getEntries = () => entries
-  clearMeasures = () => entries = []
+  clearMeasures = () => (entries = [])
 }
 
 export { mark, stop, getEntries, clearMeasures }

--- a/src/index.js
+++ b/src/index.js
@@ -26,8 +26,9 @@ function insertSorted (arr, item) {
 let mark
 let stop
 let getEntries
+let clearMeasures
 
-if (perf && perf.mark && perf.measure) {
+if (perf && perf.mark && perf.measure && perf.clearMeasures) {
   mark = name => {
     throwIfEmpty(name)
     perf.mark(`start ${name}`)
@@ -40,6 +41,7 @@ if (perf && perf.mark && perf.measure) {
     return entries[entries.length - 1]
   }
   getEntries = () => perf.getEntriesByType('measure')
+  clearMeasures = () => perf.clearMeasures()
 } else {
   let marks = {}
   let entries = []
@@ -68,6 +70,7 @@ if (perf && perf.mark && perf.measure) {
     return entry
   }
   getEntries = () => entries
+  clearMeasures = () => entries = []
 }
 
-export { mark, stop, getEntries }
+export { mark, stop, getEntries, clearMeasures }

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ if (perf && perf.mark && perf.measure && perf.clearMeasures) {
     return entry
   }
   getEntries = () => entries
-  clearMeasures = () => (entries = [])
+  clearMeasures = () => { entries = [] }
 }
 
 export { mark, stop, getEntries, clearMeasures }

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,18 @@ describe('marky', function () {
       })
   })
 
+  it('clears measures (entries)', () => {
+    marky.mark('pikachu')
+    marky.mark('pidgey')
+    marky.mark('pikachu')
+    marky.stop('pikachu')
+    marky.stop('pidgey')
+    marky.stop('pikachu')
+
+    marky.clearMeasures()
+    assert.equal(marky.getEntries().length, 0)
+  })
+
   it('does a basic mark with end defined', () => {
     marky.mark('bar')
     var res = marky.stop('bar')


### PR DESCRIPTION
This will allow to use `marky` for benchmarks. For example:

```javascript
function fn1 () {...}
function fn2 () {...}

let fn1_entries
let fn2_entries

for (let i = 0; i < 20; i++) {
  marky.mark('fn1')
  fn1()
  marky.stop('fn1')
}

fn1_entries = marky.getEntries()
marky.clearMeasures()

for (let i = 0; i < 20; i++) {
  marky.mark('fn2')
  fn2()
  marky.stop('fn2')
}

fn2_entries = marky.getEntries()
...
```

If we can `getEntries` - why not be able to clear them? :)

P.S. I'm not sure about method naming though - I've tried to follow naming from the Performance API.