### PR TITLE
also clear marks on .clear() in node env

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,10 @@ if (perf && perf.mark) {
     return entry
   }
   getEntries = () => entries
-  clear = () => { entries = [] }
+  clear = () => {
+    marks = {}
+    entries = []
+  }
 }
 
 export { mark, stop, getEntries, clear }


### PR DESCRIPTION
Ran into a bug using marky that only happened in the Browser, not in Node. Discovered that it didn't happen in Node because of the difference of clearing state in Node vs in the Browser. This PR modifies `.clear()` so that both environments are handled in the same manner.