### PR TITLE
fix: remove __esModule for IIFE output

### DIFF
--- a/config/rollup.config.iife.js
+++ b/config/rollup.config.iife.js
@@ -3,5 +3,6 @@ import config from './rollup.config'
 export default config({
   format: 'iife',
   dest: 'dist/marky.js',
-  browser: true
+  browser: true,
+  skipEsModule: true // don't add __esModule for IIFE output to maintain backwards compat with marky <=v1.2.1
 })

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -7,7 +7,8 @@ export default config => {
     output: {
       format: config.format,
       file: config.dest,
-      name: 'marky'
+      name: 'marky',
+      esModule: !config.skipEsModule
     },
     plugins: [
       buble(),


### PR DESCRIPTION
Before the Rollup upgrade, we didn't have this thing for the IIFE output:

```js
Object.defineProperty(exports, '__esModule', { value: true });
```

I'm paranoid about releasing breaking changes (this could affect how bundlers interpret the file), so I'd rather just have the output be exactly the same as before.