### PR TITLE
perf: fix Node 16 perf degradation

### DIFF
--- a/src/performance.js
+++ b/src/performance.js
@@ -1,3 +1,5 @@
 /* global performance */
-export default typeof performance !== 'undefined' && performance
 
+// TODO: Node's built-in performance API has poor performance for getEntriesByName()
+// so currently we avoid it: https://github.com/nolanlawson/marky/issues/29
+export default process.browser && typeof performance !== 'undefined' && performance


### PR DESCRIPTION
Avoids using the built-in `performance` API in Node.