### PR TITLE
fix: use node perf_hooks and return value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,12 @@ if (
   stop = name => {
     throwIfEmpty(name)
     perf.mark(`end ${name}`)
-    perf.measure(name, `start ${name}`, `end ${name}`)
+    const measure = perf.measure(name, `start ${name}`, `end ${name}`)
+    if (measure) {
+      // return value from performance.measure not supported in all browsers
+      // https://developer.mozilla.org/en-US/docs/Web/API/Performance/measure#browser_compatibility
+      return measure
+    }
     const entries = perf.getEntriesByName(name)
     return entries[entries.length - 1]
   }

--- a/src/performance.js
+++ b/src/performance.js
@@ -10,4 +10,4 @@ function safeRequire (mod) {
 
 export default process.browser
   ? (typeof performance !== 'undefined' && performance)
-  : safeRequire('perf_hooks')
+  : (typeof performance !== 'undefined' ? performance : safeRequire('perf_hooks'))

--- a/src/performance.js
+++ b/src/performance.js
@@ -1,5 +1,13 @@
 /* global performance */
 
-// TODO: Node's built-in performance API has poor performance for getEntriesByName()
-// so currently we avoid it: https://github.com/nolanlawson/marky/issues/29
-export default process.browser && typeof performance !== 'undefined' && performance
+function safeRequire (mod) {
+  try {
+    return require(mod)
+  } catch (err) {
+    // ignore
+  }
+}
+
+export default process.browser
+  ? (typeof performance !== 'undefined' && performance)
+  : safeRequire('perf_hooks')


### PR DESCRIPTION
Fixes #17 and #32 by using Node's `perf_hooks` as well as using the return value from `performance.measure`.

Interestingly the Node tests seem to fail when I use Node's built-in performance API. There may be a bug here worth investigating (or it may be that my tests are wrong).